### PR TITLE
Remove Cubify

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,6 @@ Convert 3D models into G-Code.
 From 3D printer manufacturer:
 
 - [123D Gallery](http://123dapp.com/Gallery) (from Autodesk)
-- [Cubify](http://cubify.com)
 - [Thingiverse](https://thingiverse.com) (from Makerbot)
 - [Treasure Island](http://treasure.is) (from Pirate3D)
 - [YouMagine](https://youmagine.com) (from Ultimaker)


### PR DESCRIPTION
Is closed as of Jan 31, 2016: http://www.3ders.org/articles/20151228-3d-systems-exits-consumer-marketplace-discontinues-cube-3d-printer.html