### PR TITLE
Add Truck to list of CAD tools in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ A curated list of awesome 3D printing resources.
 - [Solidworks] - 3D CAD design software. (commercial)
 - [SolveSpace] - Minimalist CAD software. (open source)
 - [Tinkercad] - Browser based free app for 3D design, electronics, and coding.
-- [Truck](https://github.com/ricosjp/truck) - Rust based CAD Kernel.
+- [Truck] - Rust based CAD Kernel.
 
 [AutoCAD]: https://www.autodesk.com/products/autocad/overview
 [Autodesk Fusion 360]: https://www.autodesk.com/products/fusion-360/personal
@@ -113,7 +113,7 @@ A curated list of awesome 3D printing resources.
 [Solidworks]: https://www.solidworks.com/
 [SolveSpace]: https://solvespace.com/index.pl
 [Tinkercad]: https://www.tinkercad.com
-
+[Truck]: https://github.com/ricosjp/truck
 
 ## Control Software
 


### PR DESCRIPTION
Add Truck, a rust based CAD kernel, to the list of CAD Tools in the readme.md file.