### PR TITLE
Add Vectiler to the list of tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -305,7 +305,7 @@ Self-Hostable:
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Vectary] - Browser-based 3D modeling.
-- [Vectiler](https://halfmaps.io/) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
+- [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 
 [BotQueue]: https://github.com/Hoektronics/BotQueue
 [Clara.io]: https://clara.io


### PR DESCRIPTION
Added [Vectiler](https://www.halfmaps.io/) as a tool for generating 3D printable models from maps.