### PR TITLE
Add Kiln — AI agent control software for 3D printers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,10 +117,12 @@ A curated list of awesome 3D printing resources.
 
 ## Control Software
 
+- [Kiln] - Open-source MCP server and CLI for AI agents to control 3D printers (OctoPrint, Moonraker, Bambu Lab, Prusa Link, Elegoo). 230 tools for fleet management, slicing, safety, and fulfillment.
 - [OctoPrint] - Web interface for 3D printer.
 - [PrintRun] - Pure Python 3d printing host software.
 - [Repetier] - Place, slice, preview and print.
 
+[Kiln]: https://github.com/codeofaxel/Kiln
 [OctoPrint]: https://octoprint.org
 [PrintRun]: https://github.com/kliment/Printrun
 [Repetier]: https://www.repetier.com/


### PR DESCRIPTION
Adds [Kiln](https://github.com/codeofaxel/Kiln) to the Control Software section.

Kiln is an open-source MCP server and CLI that lets AI agents safely control 3D printers. It supports OctoPrint, Moonraker/Klipper, Bambu Lab, Prusa Link, and Elegoo — providing 230 tools for printer control, fleet management, model marketplace search, STL slicing (PrusaSlicer/OrcaSlicer), safety validation, and manufacturing fulfillment via Craftcloud.

- **Language:** Python
- **License:** MIT
- **Install:** `pip install kiln3d`
- **Website:** https://kiln3d.com