### PR TITLE
Add MakerRepo.com

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ Self-Hostable:
 [Free3D]: https://free3d.com/
 [GrabCAD]: https://grabcad.com
 [Makerworld]: https://makerworld.com/en
-[MakerRepo]: https://github.com/makerrepo/makerrepo
+[MakerRepo]: https://makerrepo.com
 [Manyfold]: https://github.com/manyfold3d/manyfold
 [MyMiniFactory]: https://www.myminifactory.com/
 [Pinshape]: https://pinshape.com


### PR DESCRIPTION
Hi there,

I am author of https://MakerRepo.com. It's a git repository hosting service for Build123d powered CAD models. Mostly targeting 3d printer community. You can build and share your own model with others easily. Here's an example of the artifacts list for my own mini server rack project:

https://makerrepo.com/r/fangpenlin/tinyrack/artifacts/master

There are more interesting stuff like web-based generator:

https://makerrepo.com/r/fangpenlin/open-models/generator/master/a4e41cb8-a942-43b2-a375-b0da4dbe54a9

A generator can be defined as easy as like this:

```python
from build123d import *
from mr import customizable
from pydantic import BaseModel
from pydantic import Field
class BoxParameters(BaseModel):
    width: float = Field(default=10, gt=0)
    height: float = Field(default=10, gt=0)
    length: float = Field(default=10, gt=0)
@customizable(sample_parameters=BoxParameters(width=10, height=10, length=10))
def main(parameters: BoxParameters):
    box = Box(parameters.width, parameters.height, parameters.length)
    return box

```

Still in its early stage, but I think it would be a great addition to this awesome-3d-printing list, so here's the PR for adding it.