### PR TITLE
Add Kiln to Control Software

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,7 +153,7 @@ A curated list of awesome 3D printing resources.
 ## Control Software
 
 - [Bambuddy] - Self-hosted print management tool for Bambu Lab printers with real-time monitoring, print archiving, scheduling, and notifications.
-- [Kiln] - MCP server for AI agents to control 3D printers. Supports OctoPrint, Moonraker, Bambu Lab, Prusa Link, and Elegoo.
+- [Kiln] - MCP server for AI agents to control 3D printers.
 - [OctoPrint] - Web interface for 3D printer.
 - [PrintRun] - Pure Python 3d printing host software.
 - [Repetier] - Place, slice, preview and print.

--- a/readme.md
+++ b/readme.md
@@ -152,14 +152,14 @@ A curated list of awesome 3D printing resources.
 
 ## Control Software
 
-- [Kiln] - MCP server for AI agents to control 3D printers. Supports OctoPrint, Moonraker, Bambu Lab, Prusa Link, and Elegoo.
 - [Bambuddy] - Self-hosted print management tool for Bambu Lab printers with real-time monitoring, print archiving, scheduling, and notifications.
+- [Kiln] - MCP server for AI agents to control 3D printers. Supports OctoPrint, Moonraker, Bambu Lab, Prusa Link, and Elegoo.
 - [OctoPrint] - Web interface for 3D printer.
 - [PrintRun] - Pure Python 3d printing host software.
 - [Repetier] - Place, slice, preview and print.
 
-[Kiln]: https://github.com/codeofaxel/Kiln
 [Bambuddy]: https://bambuddy.cool
+[Kiln]: https://github.com/codeofaxel/Kiln
 [OctoPrint]: https://octoprint.org
 [PrintRun]: https://github.com/kliment/Printrun
 [Repetier]: https://www.repetier.com/

--- a/readme.md
+++ b/readme.md
@@ -117,10 +117,12 @@ A curated list of awesome 3D printing resources.
 
 ## Control Software
 
+- [Kiln] - MCP server for AI agents to control 3D printers. Supports OctoPrint, Moonraker, Bambu Lab, Prusa Link, and Elegoo.
 - [OctoPrint] - Web interface for 3D printer.
 - [PrintRun] - Pure Python 3d printing host software.
 - [Repetier] - Place, slice, preview and print.
 
+[Kiln]: https://github.com/codeofaxel/Kiln
 [OctoPrint]: https://octoprint.org
 [PrintRun]: https://github.com/kliment/Printrun
 [Repetier]: https://www.repetier.com/


### PR DESCRIPTION
Adds [Kiln](https://github.com/codeofaxel/Kiln) to the Control Software section.

Kiln is an open-source MCP server and CLI that lets AI agents control 3D printers. It supports OctoPrint, Moonraker/Klipper, Bambu Lab, Prusa Link, and Elegoo — with tools for slicing, job queuing, safety validation, and fleet management.

- MIT licensed
- Published on PyPI as `kiln3d`