### PR TITLE
Add PROLED3D to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -376,11 +376,11 @@ Self-Hostable:
 [gcode.ws]: https://gcode.ws
 [HelloTriangle]: https://www.hellotriangle.io
 [OctoEverywhere]: https://octoeverywhere.com
+[Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
+[PROLED3D]: https://proled3d.com
 [Vectary]: https://www.vectary.com
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
-[Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
-[PROLED3D]: https://proled3d.com
 
 ## On Demand 3D Printing Services
 

--- a/readme.md
+++ b/readme.md
@@ -365,6 +365,7 @@ Self-Hostable:
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
+- [PROLED3D](https://proled3d.com/) - Generate manufacturable LED channel letter parts from SVG (STL + DXF). Designed for real fabrication, not just 3D previews.
 
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue

--- a/readme.md
+++ b/readme.md
@@ -371,9 +371,9 @@ Self-Hostable:
 [BotQueue]: https://github.com/Hoektronics/BotQueue
 [Clara.io]: https://clara.io
 [Filameter]: https://filameter.com
-[Filwiz]: https://filwiz.com/
+[Filwiz]: https://filwiz.com
 [gcode.ws]: https://gcode.ws
-[HelloTriangle]: https://www.hellotriangle.io/
+[HelloTriangle]: https://www.hellotriangle.io
 [OctoEverywhere]: https://octoeverywhere.com
 [Polyvia3D]: https://polyvia3d.com
 [Vectary]: https://www.vectary.com/

--- a/readme.md
+++ b/readme.md
@@ -365,7 +365,7 @@ Self-Hostable:
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
-- [PROLED3D](https://proled3d.com/) - Generate manufacturable LED channel letter parts from SVG (STL + DXF). Designed for real fabrication, not just 3D previews.
+- [PROLED3D] - Generate manufacturable LED channel letter parts from SVG (STL + DXF) for real fabrication.
 
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue
@@ -378,7 +378,7 @@ Self-Hostable:
 [Polyvia3D]: https://polyvia3d.com
 [Vectary]: https://www.vectary.com/
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
-
+[PROLED3D]: https://proled3d.com
 
 ## On Demand 3D Printing Services
 

--- a/readme.md
+++ b/readme.md
@@ -370,16 +370,16 @@ Self-Hostable:
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue
 [Clara.io]: https://clara.io
+[FilamentProfilesHub]: https://filamentprofileshub.com
 [Filameter]: https://filameter.com
 [Filwiz]: https://filwiz.com
 [gcode.ws]: https://gcode.ws
 [HelloTriangle]: https://www.hellotriangle.io
 [OctoEverywhere]: https://octoeverywhere.com
 [Polyvia3D]: https://polyvia3d.com
-[Vectary]: https://www.vectary.com/
-[Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
-[FilamentProfilesHub]: https://filamentprofileshub.com
+[Vectary]: https://www.vectary.com
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
+[Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [PROLED3D]: https://proled3d.com
 
 ## On Demand 3D Printing Services

--- a/readme.md
+++ b/readme.md
@@ -355,7 +355,7 @@ Self-Hostable:
 - [3D Box Generator] - Webapp to generate STL files for boxes of custom size.
 - [BotQueue] - Control your 3D printers over the internet.
 - [Clara.io] - Cloud-based 3D modeling, animation and rendering.
-- [FilamentProfilesHub](https://filamentprofileshub.com) - Database of community-verified print settings (nozzle temp, bed temp, speed, retraction) for any printer + filament combination.
+- [FilamentProfilesHub] - Database of community-verified print settings (nozzle temp, bed temp, speed, retraction) for any printer + filament combination.
 - [Filameter] - Filament Inventory Management.
 - [Filwiz] - AI-powered filament profile generator from TDS, multi-slicer export, inventory tracking, and print troubleshooting.
 - [gcode.ws] - Gcode analyzer.
@@ -363,7 +363,7 @@ Self-Hostable:
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [Vectary] - Browser-based 3D modeling.
-- [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
+- [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
 - [PROLED3D] - Generate manufacturable LED channel letter parts from SVG (STL + DXF) for real fabrication.
 
@@ -378,6 +378,8 @@ Self-Hostable:
 [Polyvia3D]: https://polyvia3d.com
 [Vectary]: https://www.vectary.com/
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
+[FilamentProfilesHub]: https://filamentprofileshub.com
+[Vectiler]: https://www.halfmaps.io/3d-map-exporter
 [PROLED3D]: https://proled3d.com
 
 ## On Demand 3D Printing Services


### PR DESCRIPTION
Adds a web tool that converts SVG into STL/DXF for real LED sign fabrication.