### PR TITLE
Add QRCode2STL tool to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -362,6 +362,7 @@ Self-Hostable:
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
+- [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
@@ -376,6 +377,7 @@ Self-Hostable:
 [HelloTriangle]: https://www.hellotriangle.io/
 [OctoEverywhere]: https://octoeverywhere.com
 [Polyvia3D]: https://polyvia3d.com
+[QRCode2STL]: https://qrcode2stl.printer.tools
 [Vectary]: https://www.vectary.com/
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 


### PR DESCRIPTION
Ei Gude, QRCode2STL is a browser tool to generate customizable 3D printable QR Codes, Spotify codes and text labels. That I have been working on for quite some time now (https://github.com/flxn/qrcode2stl).

I also added your list to my own small collection of 3D printing related resources: https://printer.tools/