### PR TITLE
Add Filament Price Tracker to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -354,8 +354,8 @@ Self-Hostable:
 - [3D Box Generator] - Webapp to generate STL files for boxes of custom size.
 - [BotQueue] - Control your 3D printers over the internet.
 - [Clara.io] - Cloud-based 3D modeling, animation and rendering.
-- [Filament Price Tracker](https://filamentpricetracker.com) - Tracks 3D printing filament prices and price history.
-- [FilamentProfilesHub](https://filamentprofileshub.com) - Database of community-verified print settings (nozzle temp, bed temp, speed, retraction) for any printer + filament combination.
+- [Filament Price Tracker] - Tracks 3D printing filament prices and price history.
+- [FilamentProfilesHub] - Database of community-verified print settings for any printer + filament combination.
 - [Filameter] - Filament Inventory Management.
 - [Filwiz] - AI-powered filament profile generator from TDS, multi-slicer export, inventory tracking, and print troubleshooting.
 - [Free Universal Construction Kit] - A set of universal connectors to link together popular toy construction systems.
@@ -368,10 +368,11 @@ Self-Hostable:
 - [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
 
-
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue
 [Clara.io]: https://clara.io
+[Filament Price Tracker]: https://filamentpricetracker.com
+[FilamentProfilesHub]: https://filamentprofileshub.com
 [Filameter]: https://filameter.com
 [Filwiz]: https://filwiz.com/
 [Free Universal Construction Kit]: https://fffff.at/free-universal-construction-kit/

--- a/readme.md
+++ b/readme.md
@@ -354,6 +354,7 @@ Self-Hostable:
 - [3D Box Generator] - Webapp to generate STL files for boxes of custom size.
 - [BotQueue] - Control your 3D printers over the internet.
 - [Clara.io] - Cloud-based 3D modeling, animation and rendering.
+- [Filament Price Tracker](https://filamentpricetracker.com) - Tracks 3D printing filament prices and price history.
 - [FilamentProfilesHub](https://filamentprofileshub.com) - Database of community-verified print settings (nozzle temp, bed temp, speed, retraction) for any printer + filament combination.
 - [Filameter] - Filament Inventory Management.
 - [Filwiz] - AI-powered filament profile generator from TDS, multi-slicer export, inventory tracking, and print troubleshooting.
@@ -366,7 +367,7 @@ Self-Hostable:
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
-- [Filament Price Tracker](https://filamentpricetracker.com) - Tracks 3D printing filament prices and price history.
+
 
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue

--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,7 @@ Self-Hostable:
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler](https://www.halfmaps.io/3d-map-exporter) - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
+- [Filament Price Tracker](https://filamentpricetracker.com) - Tracks 3D printing filament prices and price history.
 
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue


### PR DESCRIPTION
Adds Filament Price Tracker, a web-based tool that tracks 3D printing filament prices and price history.

The site is live at https://filamentpricetracker.com.

- Entry follows the required format
- Title uses AP title case
- Placed alphabetically in the Online Tools section