### PR TITLE
Add Gridfinity Layout Tool to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -360,6 +360,7 @@ Self-Hostable:
 - [Filwiz] - AI-powered filament profile generator from TDS, multi-slicer export, inventory tracking, and print troubleshooting.
 - [Free Universal Construction Kit] - A set of universal connectors to link together popular toy construction systems.
 - [gcode.ws] - Gcode analyzer.
+- [Gridfinity Layout Tool] - Browser-based tool to plan Gridfinity drawer layouts and export STL, STEP, and 3MF files for 3D printing.
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
@@ -378,6 +379,7 @@ Self-Hostable:
 [Filwiz]: https://filwiz.com/
 [Free Universal Construction Kit]: https://fffff.at/free-universal-construction-kit/
 [gcode.ws]: https://gcode.ws
+[Gridfinity Layout Tool]: https://gridfinitylayouttool.com
 [HelloTriangle]: https://www.hellotriangle.io
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database


### PR DESCRIPTION
## Submission

**Disclosure:** I'm the creator/maintainer of gridfinitylayouttool.com.

Adds [Gridfinity Layout Tool](https://gridfinitylayouttool.com) to the Online Tools section.

### Why it fits
- Free, browser-based, no login
- Generates STL / STEP / 3MF for printing
- Plans drawer layouts and custom Gridfinity bins/baseplates
- Complements existing entries like 3D Box Generator and QRCode2STL

### Checklist
- [x] Searched for duplicates
- [x] Used the format: `[Name](link) - Description.`
- [x] AP-style title casing
- [x] Inserted alphabetically
- [x] One suggestion in this PR