### PR TITLE
Add PrintCostCalc to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -363,6 +363,7 @@ Self-Hostable:
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
+- [PrintCostCalc] - Free browser calculators for print cost and Klipper/Marlin calibration (rotation_distance, E-steps, flow rate, volumetric flow).
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
@@ -382,6 +383,7 @@ Self-Hostable:
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
+[PrintCostCalc]: https://3dprintcostcalc.top
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Vectary]: https://www.vectary.com/


### PR DESCRIPTION
Adds **PrintCostCalc** to the Online Tools section.

It's a free, browser-based set of 3D printing calculators — print cost/quoting plus extruder calibration tools that fit this list well: Klipper `rotation_distance`, Marlin E-steps, flow rate / extrusion multiplier, and volumetric flow. No login, runs client-side.

- Site: https://3dprintcostcalc.top
- Format follows `contributing.md` (title-case name, reference-style link, entry placed alphabetically in both the list and the link references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)