### PR TITLE
Add PNGtoSTL to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -364,6 +364,7 @@ Self-Hostable:
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
+- [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
@@ -384,6 +385,7 @@ Self-Hostable:
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
+[PNGtoSTL]: https://pngtostl.net/samples?utm_source=github_awesome_3d_printing&utm_medium=referral&utm_campaign=sample_gallery&utm_content=resource_list_pr
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Vectary]: https://www.vectary.com/

--- a/readme.md
+++ b/readme.md
@@ -385,7 +385,7 @@ Self-Hostable:
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
-[PNGtoSTL]: https://pngtostl.net/samples?utm_source=github_awesome_3d_printing&utm_medium=referral&utm_campaign=sample_gallery&utm_content=resource_list_pr
+[PNGtoSTL]: https://pngtostl.net
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Vectary]: https://www.vectary.com/


### PR DESCRIPTION
## Summary

Adds PNGtoSTL to the Online Tools section.

PNGtoSTL is a browser-based image-to-STL workspace for practical 3D printing outputs such as reliefs, lithophanes, logo badges, and heightmap surfaces. The linked examples page includes source images, previews, mesh metrics, and downloadable STL examples.

## Checklist

- [x] Searched the README for PNGtoSTL, image-to-STL, lithophane, heightmap, and relief duplicates.
- [x] Added one resource only.
- [x] Used the existing `[Resource Name] - Description text.` format.
- [x] Placed the entry in the Online Tools section near similar browser-based STL tools.
