### PR TITLE
Add img2stl.art to Online Tools section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -362,6 +362,7 @@ Self-Hostable:
 - [gcode.ws] - Gcode analyzer.
 - [Gridfinity Layout Tool] - Browser-based tool to plan Gridfinity drawer layouts and export STL, STEP, and 3MF files for 3D printing.
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
+- [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
@@ -369,7 +370,6 @@ Self-Hostable:
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
 - [PROLED3D] - Generate manufacturable LED channel letter parts from SVG (STL + DXF) for real fabrication.
-- [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
 
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue
@@ -382,6 +382,7 @@ Self-Hostable:
 [gcode.ws]: https://gcode.ws
 [Gridfinity Layout Tool]: https://gridfinitylayouttool.com
 [HelloTriangle]: https://www.hellotriangle.io
+[img2stl.art]: https://img2stl.art
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
@@ -389,7 +390,6 @@ Self-Hostable:
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Vectary]: https://www.vectary.com/
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
-[img2stl.art]: https://img2stl.art
 
 
 ## On Demand 3D Printing Services

--- a/readme.md
+++ b/readme.md
@@ -369,6 +369,7 @@ Self-Hostable:
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
 - [PROLED3D] - Generate manufacturable LED channel letter parts from SVG (STL + DXF) for real fabrication.
+- [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
 
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue
@@ -388,6 +389,7 @@ Self-Hostable:
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Vectary]: https://www.vectary.com/
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
+[img2stl.art]: https://img2stl.art
 
 
 ## On Demand 3D Printing Services


### PR DESCRIPTION
## Add [img2stl.art](https://img2stl.art) to Online Tools

img2stl.art is an AI-powered tool that converts photos to printable STL files in seconds. It fits naturally in the Online Tools section alongside other browser-based 3D utilities.

- Free tier available, no account needed
- Single-photo input → ready-to-print STL output
- Complements existing tools like Vectary, Polyvia3D, and QRCode2STL