### PR TITLE
Add Ritn3D to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -365,6 +365,7 @@ Self-Hostable:
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
+- [Ritn3D] - Convert a floor plan into a 3D printable house model. Generates an interactive 3D interior from a PDF, JPG, or PNG floor plan; exports STL with manifold geometry, sealed walls, and a flat base — ready for any slicer at 1:100 or 1:50 scale.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
@@ -386,6 +387,7 @@ Self-Hostable:
 [Polyvia3D]: https://polyvia3d.com
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
+[Ritn3D]: https://www.ritn3d.com
 [Vectary]: https://www.vectary.com/
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
 

--- a/readme.md
+++ b/readme.md
@@ -365,7 +365,7 @@ Self-Hostable:
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
-- [Ritn3D] - Convert a floor plan into a 3D printable house model. Generates an interactive 3D interior from a PDF, JPG, or PNG floor plan; exports STL with manifold geometry, sealed walls, and a flat base — ready for any slicer at 1:100 or 1:50 scale.
+- [Ritn3D] - Convert a floor plan into a 3D printable house model.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.


### PR DESCRIPTION
Ritn3D produces 3D printable house models from 2D floor plans — useful for architectural study prints, real-estate closing gifts, and miniature home models. STL output is manifold, sealed, with a flat base, so it goes straight into Cura / PrusaSlicer / Bambu Studio / Lychee without mesh repair.

Free tier (no STL export). STL download included in the Pro+ tier with 10 downloads/month + rollover credits for extras.

Entry added alphabetically in **Online Tools** between QRCode2STL and Vectary, plus matching reference link in the link-definitions list.