### PR TITLE
Add SimplexGen to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -370,6 +370,7 @@ Self-Hostable:
 - [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Ritn3D] - Convert a floor plan into a 3D printable house model.
+- [SimplexGen] - Browser-based AI image-to-3D generator with a full mesh editing toolkit (simplify, smooth, repair, retopology, boolean, UV) and a 3D-print prep editor.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
@@ -394,6 +395,7 @@ Self-Hostable:
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Ritn3D]: https://www.ritn3d.com
+[SimplexGen]: https://simplexgen.com
 [Vectary]: https://www.vectary.com/
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
 


### PR DESCRIPTION
Adds SimplexGen (https://simplexgen.com) to Online Tools. Browser-based AI image-to-3D generator with a mesh-editing toolkit and 3D-print prep. Used the reference-style link format and alphabetical placement.