### PR TITLE
Add MakerX Designs to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -366,6 +366,7 @@ Self-Hostable:
 - [Gridfinity Layout Tool] - Browser-based tool to plan Gridfinity drawer layouts and export STL, STEP, and 3MF files for 3D printing.
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
+- [MakerX Designs] - Free browser-based 3D-printing utilities: tolerance/fit gauge, filament and print-cost calculators, STL viewer, Gridfinity planner, and in-browser calibration & parametric STL generators.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
@@ -390,6 +391,7 @@ Self-Hostable:
 [Gridfinity Layout Tool]: https://gridfinitylayouttool.com
 [HelloTriangle]: https://www.hellotriangle.io
 [img2stl.art]: https://img2stl.art
+[MakerX Designs]: https://makerxdesigns.com/utilities.html
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com


### PR DESCRIPTION
Adds MakerX Designs -- a free suite of browser-based 3D-printing utilities (calculators, STL viewer/analyzer, Gridfinity planner, and in-browser calibration/parametric STL generators). Runs entirely client-side, no signup. Added alphabetically in the Online Tools section using the existing reference-link style.