### PR TITLE
Add Prompt2CAD to CAD tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -127,6 +127,7 @@ A curated list of awesome 3D printing resources.
 - [OpenSCAD] - 3D CAD tool that describes the 3D model with code. (open source)
 - [Onshape]
 - [Plasticity] - Solid and surface modeling desktop app. (commercial)
+- [Prompt2CAD] - Browser-based AI CAD tool that turns text prompts into parametric CAD models and exports STEP, DXF, STL, OBJ, and GLB. (freemium)
 - [Rhinoceros 3D] - CAD application software. (commercial)
 - [Shapr3D]
 - [Solidworks] - 3D CAD design software. (commercial)
@@ -144,6 +145,7 @@ A curated list of awesome 3D printing resources.
 [Onshape]: https://www.onshape.com/en/
 [OpenSCAD]: https://openscad.org
 [Plasticity]: https://www.plasticity.xyz/
+[Prompt2CAD]: https://prompt2cad.com
 [Rhinoceros 3D]: https://www.rhino3d.com
 [Shapr3D]: https://www.shapr3d.com/
 [Solidworks]: https://www.solidworks.com/

--- a/readme.md
+++ b/readme.md
@@ -45,6 +45,7 @@ A curated list of awesome 3D printing resources.
 - [Flsun]
 - [Formlabs]
 - [HevORT] - Advanced DIY 3D Printer.
+- [innovatiQ]
 - [Infimech]
 - [Kentstrapper]
 - [Lulzbot] - Open hardware 3D printers and accessories.
@@ -85,6 +86,7 @@ A curated list of awesome 3D printing resources.
 [Flsun]: https://flsun3d.com/
 [Formlabs]: https://formlabs.com
 [HevORT]: https://hevort.com/
+[innovatiQ]: https://www.innovatiq.com/
 [Infimech]: https://infimech.com/
 [Kentstrapper]: https://kentstrapper.com
 [Lulzbot]: https://lulzbot.com/
@@ -177,7 +179,7 @@ A curated list of awesome 3D printing resources.
 - [CFS] - Creality Filament System for multi-color printing.
 - [EnragedRabbitProject] - Multi-color addon for Voron 3D printers.
 
-[AMS]: https://eu.store.bambulab.com/products/ams-multicolor-printing
+[AMS]: https://bambulab.com/en/ams
 [BoxTurtle]: https://github.com/ArmoredTurtle/BoxTurtle
 [CFS]: https://store.creality.com/products/cfs-creality-filament-system
 [EnragedRabbitProject]: https://github.com/EtteGit/EnragedRabbitProject
@@ -368,6 +370,7 @@ Self-Hostable:
 - [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
+- [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Ritn3D] - Convert a floor plan into a 3D printable house model.
 - [SimplexGen] - Browser-based AI image-to-3D generator with a full mesh editing toolkit (simplify, smooth, repair, retopology, boolean, UV) and a 3D-print prep editor.
@@ -392,6 +395,7 @@ Self-Hostable:
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
+[PNGtoSTL]: https://pngtostl.net
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Ritn3D]: https://www.ritn3d.com

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,6 @@ A curated list of awesome 3D printing resources.
 - [Flsun]
 - [Formlabs]
 - [HevORT] - Advanced DIY 3D Printer.
-- [innovatiQ]
 - [Infimech]
 - [Kentstrapper]
 - [Lulzbot] - Open hardware 3D printers and accessories.
@@ -86,7 +85,6 @@ A curated list of awesome 3D printing resources.
 [Flsun]: https://flsun3d.com/
 [Formlabs]: https://formlabs.com
 [HevORT]: https://hevort.com/
-[innovatiQ]: https://www.innovatiq.com/
 [Infimech]: https://infimech.com/
 [Kentstrapper]: https://kentstrapper.com
 [Lulzbot]: https://lulzbot.com/
@@ -179,7 +177,7 @@ A curated list of awesome 3D printing resources.
 - [CFS] - Creality Filament System for multi-color printing.
 - [EnragedRabbitProject] - Multi-color addon for Voron 3D printers.
 
-[AMS]: https://bambulab.com/en/ams
+[AMS]: https://eu.store.bambulab.com/products/ams-multicolor-printing
 [BoxTurtle]: https://github.com/ArmoredTurtle/BoxTurtle
 [CFS]: https://store.creality.com/products/cfs-creality-filament-system
 [EnragedRabbitProject]: https://github.com/EtteGit/EnragedRabbitProject
@@ -370,7 +368,6 @@ Self-Hostable:
 - [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
-- [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Ritn3D] - Convert a floor plan into a 3D printable house model.
 - [SimplexGen] - Browser-based AI image-to-3D generator with a full mesh editing toolkit (simplify, smooth, repair, retopology, boolean, UV) and a 3D-print prep editor.
@@ -395,7 +392,6 @@ Self-Hostable:
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
-[PNGtoSTL]: https://pngtostl.net
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Ritn3D]: https://www.ritn3d.com


### PR DESCRIPTION
Adds Prompt2CAD to the CAD Tools section. It is a browser-based AI CAD tool for generating parametric CAD models from text prompts, with exports for common CAD and 3D printing formats.