### PR TITLE
Add StackSheriff G-code Cost Analyzer to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -372,6 +372,7 @@ Self-Hostable:
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Ritn3D] - Convert a floor plan into a 3D printable house model.
 - [SimplexGen] - Browser-based AI image-to-3D generator with a full mesh editing toolkit (simplify, smooth, repair, retopology, boolean, UV) and a 3D-print prep editor.
+- [StackSheriff G-code Cost Analyzer] - Free browser tool that parses a sliced G-code file to estimate filament cost and print time.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
@@ -398,6 +399,7 @@ Self-Hostable:
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Ritn3D]: https://www.ritn3d.com
 [SimplexGen]: https://simplexgen.com
+[StackSheriff G-code Cost Analyzer]: https://stacksheriff.com/toolbox/gcode-cost-analyzer/
 [Vectary]: https://www.vectary.com/
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
 


### PR DESCRIPTION
Adds a free, browser-based G-code cost/time analyzer to the **Online Tools** section (placed alphabetically, reference-style link to match the section's format).

- **Tool:** https://stacksheriff.com/toolbox/gcode-cost-analyzer/
- **What it does:** parses a sliced G-code file and estimates filament cost and print time. Free, no signup.
- Fits alongside the other browser-based analyzers already listed (gcode.ws, GCodex).

Thanks for maintaining the list!