### PR TITLE
Add NozzleMath to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -370,6 +370,7 @@ Self-Hostable:
 - [Gridfinity Layout Tool] - Browser-based tool to plan Gridfinity drawer layouts and export STL, STEP, and 3MF files for 3D printing.
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
+- [NozzleMath] - Free calculators for 3D print cost, filament cost, resin cost, electricity cost, and pricing prints for sale.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
@@ -394,6 +395,7 @@ Self-Hostable:
 [Gridfinity Layout Tool]: https://gridfinitylayouttool.com
 [HelloTriangle]: https://www.hellotriangle.io
 [img2stl.art]: https://img2stl.art
+[NozzleMath]: https://nozzlemath.com
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com


### PR DESCRIPTION
Adds [NozzleMath](https://nozzlemath.com) — free browser calculators for 3D-print costing: total print cost, filament cost per print, resin cost, printer electricity cost, and a pricing calculator for people selling prints. No signup, no ads, formulas documented on each page.

Disclosure: I'm the author of the site. Checked previous suggestions for duplicates; inserted alphabetically in the list and the link references.