### PR TITLE
Add gottrix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -370,6 +370,7 @@ Self-Hostable:
 - [Free Universal Construction Kit] - A set of universal connectors to link together popular toy construction systems.
 - [gcode.ws] - Gcode analyzer.
 - [GCodex] - Free browser-based G-Code viewer, simulator and analyzer for CNC and 3D printing. No upload, no signup required.
+- [gottrix] - Browser-based 3D file converter supporting STL, OBJ, GLB, GLTF, and PLY. Runs entirely client-side via WebAssembly; no uploads, works offline.
 - [Gridfinity Layout Tool] - Browser-based tool to plan Gridfinity drawer layouts and export STL, STEP, and 3MF files for 3D printing.
 - [HelloTriangle] - Cloud-based 3D modeling using Python.
 - [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
@@ -394,6 +395,7 @@ Self-Hostable:
 [Free Universal Construction Kit]: https://fffff.at/free-universal-construction-kit/
 [gcode.ws]: https://gcode.ws
 [GCodex]: https://gcodex.tech/
+[gottrix]: https://gottrix.app/en/stl-to-glb
 [Gridfinity Layout Tool]: https://gridfinitylayouttool.com
 [HelloTriangle]: https://www.hellotriangle.io
 [img2stl.art]: https://img2stl.art


### PR DESCRIPTION
Adding gottrix (https://gottrix.app), a browser-based 3D file converter (STL, OBJ, GLB, GLTF, PLY), part of a larger 500+ tool client-side file conversion suite. Runs entirely via WebAssembly, no uploads. Closed-source, free to use. I'm the maintainer, disclosing that here.