### PR TITLE
Add PartFit 3D to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -382,6 +382,7 @@ Self-Hostable:
 - [img2stl.art] - AI-powered image to 3D printable STL converter. Upload a photo and get a ready-to-print STL file in seconds.
 - [Meshdiff] - Compare two versions of a 3D model (STL, 3MF, OBJ) and visualize the differences.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
+- [PartFit 3D] - Browser-based STL and 3MF splitter that checks each cut part against a printer's build volume, with local processing and STL/3MF export.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
 - [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
@@ -408,6 +409,7 @@ Self-Hostable:
 [Meshdiff]: https://meshdiff.com
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
+[PartFit 3D]: https://partfit3d.com/
 [Polyvia3D]: https://polyvia3d.com
 [PNGtoSTL]: https://pngtostl.net
 [PROLED3D]: https://proled3d.com


### PR DESCRIPTION
Add PartFit 3D as a browser-based STL and 3MF splitting and build-volume checking tool. Model processing stays local in the browser.