### PR TITLE
Add Extrabold Tools to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -371,7 +371,7 @@ Self-Hostable:
 - [3D Box Generator] - Webapp to generate STL files for boxes of custom size.
 - [BotQueue] - Control your 3D printers over the internet.
 - [Clara.io] - Cloud-based 3D modeling, animation and rendering.
-- [Extrabold Tools](https://www.extrabold.tools/gridfinity-baseplate) - Free browser-based Gridfinity baseplate generator with live 3D preview, exact-fit sizing, printer-aware splitting, CLICKbase support, and STL and 3MF export.
+- [Extrabold Tools] - Free browser-based Gridfinity baseplate generator with live 3D preview, exact-fit sizing, printer-aware splitting, CLICKbase support, and STL and 3MF export.
 - [Filament Price Tracker] - Tracks 3D printing filament prices and price history.
 - [FilamentProfilesHub] - Database of community-verified print settings for any printer + filament combination.
 - [Filameter] - Filament Inventory Management.
@@ -397,6 +397,7 @@ Self-Hostable:
 [3D Box Generator]: https://github.com/javisperez/box-stl-generator
 [BotQueue]: https://github.com/Hoektronics/BotQueue
 [Clara.io]: https://clara.io
+[Extrabold Tools]: https://www.extrabold.tools/
 [Filament Price Tracker]: https://filamentpricetracker.com
 [FilamentProfilesHub]: https://filamentprofileshub.com
 [Filameter]: https://filameter.com

--- a/readme.md
+++ b/readme.md
@@ -367,7 +367,6 @@ Self-Hostable:
 
 ## Online Tools
 
-
 - [3D Box Generator] - Webapp to generate STL files for boxes of custom size.
 - [BotQueue] - Control your 3D printers over the internet.
 - [Clara.io] - Cloud-based 3D modeling, animation and rendering.

--- a/readme.md
+++ b/readme.md
@@ -367,9 +367,11 @@ Self-Hostable:
 
 ## Online Tools
 
+
 - [3D Box Generator] - Webapp to generate STL files for boxes of custom size.
 - [BotQueue] - Control your 3D printers over the internet.
 - [Clara.io] - Cloud-based 3D modeling, animation and rendering.
+- [Extrabold Tools](https://www.extrabold.tools/gridfinity-baseplate) - Free browser-based Gridfinity baseplate generator with live 3D preview, exact-fit sizing, printer-aware splitting, CLICKbase support, and STL and 3MF export.
 - [Filament Price Tracker] - Tracks 3D printing filament prices and price history.
 - [FilamentProfilesHub] - Database of community-verified print settings for any printer + filament combination.
 - [Filameter] - Filament Inventory Management.


### PR DESCRIPTION
Adds Extrabold Tools to the Online Tools section.

Extrabold Tools is a free, no-sign-up browser-based Gridfinity baseplate generator with live 3D preview, exact-fit sizing, printer-aware splitting, CLICKbase support, and STL/3MF export.

The entry is placed alphabetically and follows the list’s contribution format.