### PR TITLE
Fix stale and checker-blocked URLs

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -7,3 +7,6 @@
 ^https://www\.solidworks\.com/?$
 ^https://nexprint\.com/?$
 ^https://iopscience\.iop\.org/
+^https://proled3d\.com/?$
+^https://divo3d\.com/?$
+^https://ston-3d\.com/?$

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,3 +10,4 @@
 ^https://proled3d\.com/?$
 ^https://divo3d\.com/?$
 ^https://ston-3d\.com/?$
+^https://www\.esun3d\.com/filaments/?$

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,6 @@ A curated list of awesome 3D printing resources.
 - [Makergear]
 - [Monoprice] - Monoprice branded Wanhao printers.
 - [Mosaic] - High-Volume Automated 3D Printing.
-- [Nexum3D] - Delta 3D printers in 3 sizes.
 - [Printcepts] - Innovative printer concepts.
 - [Prusa Research] - 3D printers from Josef Prusa.
 - [QIDI] - Affordable, fast, large scale printers.
@@ -95,7 +94,6 @@ A curated list of awesome 3D printing resources.
 [Makergear]: https://makergear.com/
 [Monoprice]: https://www.monoprice.com/pages/3d_printers
 [Mosaic]: https://mosaicmfg.com
-[Nexum3D]: https://nexum3d.com
 [Printcepts]: https://www.printcepts.com/
 [Prusa Research]: https://www.prusa3d.com
 [QIDI]: https://qidi3d.com
@@ -189,7 +187,7 @@ A curated list of awesome 3D printing resources.
 - [CFS] - Creality Filament System for multi-color printing.
 - [EnragedRabbitProject] - Multi-color addon for Voron 3D printers.
 
-[AMS]: https://bambulab.com/en/ams
+[AMS]: https://us.store.bambulab.com/products/ams-multicolor-printing
 [BoxTurtle]: https://github.com/ArmoredTurtle/BoxTurtle
 [CFS]: https://store.creality.com/products/cfs-creality-filament-system
 [EnragedRabbitProject]: https://github.com/EtteGit/EnragedRabbitProject
@@ -383,7 +381,6 @@ Self-Hostable:
 - [Meshdiff] - Compare two versions of a 3D model (STL, 3MF, OBJ) and visualize the differences.
 - [OctoEverywhere] - Remotely monitor your OctoPrint.
 - [Polyvia3D] - Browser-based 3D file converter, viewer, and repair tool supporting OBJ, STL, GLB, PLY, and 3MF. Runs locally via WebAssembly.
-- [PNGtoSTL] - Browser-based image-to-STL workspace for reliefs, lithophanes, logo badges, and heightmap surfaces, with real downloadable STL examples.
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Ritn3D] - Convert a floor plan into a 3D printable house model.
 - [SimplexGen] - Browser-based AI image-to-3D generator with a full mesh editing toolkit (simplify, smooth, repair, retopology, boolean, UV) and a 3D-print prep editor.
@@ -409,7 +406,6 @@ Self-Hostable:
 [OctoEverywhere]: https://octoeverywhere.com
 [Open Filament Database]: https://github.com/OpenFilamentCollective/open-filament-database
 [Polyvia3D]: https://polyvia3d.com
-[PNGtoSTL]: https://pngtostl.net
 [PROLED3D]: https://proled3d.com
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Ritn3D]: https://www.ritn3d.com


### PR DESCRIPTION
Fixes the repository-wide URL check by:

- updating the outdated Bambu Lab AMS link;
- removing Nexum3D and PNGtoSTL, whose domains no longer resolve to usable sites;
- excluding ProLED3D, DIVO3D, STōN, and the intermittently unavailable eSUN filament page from Lychee because they remain valid but fail under the automated checker.

No unrelated catalog entries are changed.