### PR TITLE
Add BaskıUsta to On Demand 3D Printing Services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -421,6 +421,7 @@ Self-Hostable:
 ## On Demand 3D Printing Services
 
 - [3D Hubs]
+- [BaskıUsta] - Turkish FDM 3D printing service with instant STL/3MF quoting and nationwide delivery.
 - [Beamler] - Global industrial 3D printer network.
 - [Craftcloud] - Streamlined 3D Printing Service.
 - [Jiga] - Manufacturing as a service with known machine shops.
@@ -433,6 +434,7 @@ Self-Hostable:
 - [Upside Parts] - Greater Boston 3D printing service offering FDM, SLA and SLS with nationwide shipping.
 
 [3D Hubs]: https://www.hubs.com/
+[BaskıUsta]: https://baskiusta.com
 [Beamler]: https://www.beamler.com/
 [Craftcloud]: https://craftcloud3d.com/
 [Jiga]: https://jiga.io


### PR DESCRIPTION
Adds BaskıUsta — an online FDM 3D printing service in Turkey.

Customers upload an STL/3MF file, get an instant quote from a geometry-based pricing engine, and receive the printed parts by courier anywhere in Turkey. Production runs on Bambu Lab hardware; PLA, ABS, PETG and TPU are supported.

It fills a gap in the list: there is currently no on-demand service covering Turkey.

- Entry is alphabetically placed and uses the existing reference-link format.