### PR TITLE
Add stl-simplify to Online Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -387,6 +387,7 @@ Self-Hostable:
 - [QRCode2STL] - Browser-based generator for 3D printable QR codes, Spotify codes, and text tags.
 - [Ritn3D] - Convert a floor plan into a 3D printable house model.
 - [SimplexGen] - Browser-based AI image-to-3D generator with a full mesh editing toolkit (simplify, smooth, repair, retopology, boolean, UV) and a 3D-print prep editor.
+- [stl-simplify] - Open-source library to decimate huge STL and 3D-scan meshes to a printable triangle budget, in the browser or Node.
 - [Vectary] - Browser-based 3D modeling.
 - [Vectiler] - Online tool to generate 3D printable map and terrain models from real-world geographic data.
 - [Open Filament Database] - Open, community-driven database of filament materials, colors, and print settings.
@@ -414,6 +415,7 @@ Self-Hostable:
 [QRCode2STL]: https://qrcode2stl.printer.tools
 [Ritn3D]: https://www.ritn3d.com
 [SimplexGen]: https://simplexgen.com
+[stl-simplify]: https://github.com/ariburaco/stl-simplify
 [Vectary]: https://www.vectary.com/
 [Vectiler]: https://www.halfmaps.io/3d-map-exporter
 


### PR DESCRIPTION
Adds `stl-simplify` — an MIT-licensed library that decimates oversized STL / 3D-scan / AI-generated meshes down to a printable triangle budget, in the browser or Node/Bun.

Why it may be useful to this list: scanned and AI-generated models routinely ship with millions of triangles that choke slicers, and meshoptimizer's topology-preserving `simplify()` barely shrinks them because the meshes are high-genus (thousands of tiny tunnels). The library documents that failure mode and falls back to `simplifySloppy()` automatically — 2,035,912 → 293,396 triangles in ~5s on a real scan, bounding box preserved.

Repo: https://github.com/ariburaco/stl-simplify